### PR TITLE
Add simple model factories

### DIFF
--- a/src/models/Animal.js
+++ b/src/models/Animal.js
@@ -1,5 +1,25 @@
-export default class Animal {
-  constructor(name = 'Animal') {
-    this.name = name
+// Factory for creating Animal objects with sensible defaults
+
+export function createAnimal(options = {}) {
+  const {
+    type = 'Chicken',
+    favoriteFoods = ['Grass'],
+    hunger = { current: 0, max: 100 },
+    thirst = { current: 0, max: 100 },
+    mood = 'Calm',
+    output = 'Eggs',
+    collarZone = null,
+    tilePos = { row: null, col: null }
+  } = options
+
+  return {
+    type,
+    favoriteFoods: [...favoriteFoods],
+    hunger: { ...hunger },
+    thirst: { ...thirst },
+    mood,
+    output,
+    collarZone: collarZone ? [...collarZone] : null,
+    tilePos: { ...tilePos }
   }
 }

--- a/src/models/Plant.js
+++ b/src/models/Plant.js
@@ -1,5 +1,31 @@
-export default class Plant {
-  constructor(name = 'Plant') {
-    this.name = name
+// Simple factory for creating Plant objects
+// The factory allows overriding defaults via an options object
+
+export function createPlant(options = {}) {
+  const {
+    type = 'Grass',
+    growthStage = 'Seedling',
+    preferredSeason = 'Spring',
+    waterRequired = 1,
+    fertilizerRequired = 0,
+    tolerance = {
+      minWater: 0,
+      maxWater: 10,
+      minFertilizer: 0,
+      maxFertilizer: 10
+    },
+    yieldAmount = 1,
+    tilePos = { row: null, col: null }
+  } = options
+
+  return {
+    type,
+    growthStage,
+    preferredSeason,
+    waterRequired,
+    fertilizerRequired,
+    tolerance: { ...tolerance },
+    yield: yieldAmount,
+    tilePos: { ...tilePos }
   }
 }

--- a/src/models/Soil.js
+++ b/src/models/Soil.js
@@ -1,5 +1,17 @@
-export default class Soil {
-  constructor(type = 'Soil') {
-    this.type = type
+// Factory for creating Soil objects
+
+export function createSoil(options = {}) {
+  const {
+    fertility = 1,
+    health = { current: 100, max: 100 },
+    recoveryRate = 1,
+    tilePos = { row: null, col: null }
+  } = options
+
+  return {
+    fertility,
+    health: { ...health },
+    recoveryRate,
+    tilePos: { ...tilePos }
   }
 }

--- a/src/stores/board.js
+++ b/src/stores/board.js
@@ -1,8 +1,8 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import Plant from '../models/Plant'
-import Animal from '../models/Animal'
-import Soil from '../models/Soil'
+import { createPlant } from '../models/Plant'
+import { createAnimal } from '../models/Animal'
+import { createSoil } from '../models/Soil'
 
 export const useBoardStore = defineStore('board', () => {
   const size = 6
@@ -14,7 +14,7 @@ export const useBoardStore = defineStore('board', () => {
         col,
         plant: null,
         animal: null,
-        soil: new Soil()
+        soil: createSoil({ tilePos: { row, col } })
       }))
     )
   }


### PR DESCRIPTION
## Summary
- add factory creators for Plant, Animal and Soil models
- use soil factory when creating the board in Pinia store

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866e9b2f03883278a711bb074e97843