### PR TITLE
Add game end overlay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import MainFieldGrid from './components/MainFieldGrid.vue'
 import AssemblyArea from './components/AssemblyArea.vue'
 import VillagerGate from './components/VillagerGate.vue'
+import GameEndPanel from './components/GameEndPanel.vue'
 </script>
 
 <template>
@@ -9,6 +10,7 @@ import VillagerGate from './components/VillagerGate.vue'
     <MainFieldGrid />
     <AssemblyArea />
     <VillagerGate />
+    <GameEndPanel />
   </main>
 </template>
 

--- a/src/components/GameEndPanel.vue
+++ b/src/components/GameEndPanel.vue
@@ -1,0 +1,72 @@
+<template>
+  <div v-if="visible" class="overlay">
+    <div class="panel">
+      <h2>{{ game.win ? 'You Win!' : 'Game Over' }}</h2>
+      <p>Final Score: {{ finalScore }}</p>
+      <p>Villagers Served: {{ villagersServed }}</p>
+      <p>Turns Survived: {{ game.turn }}</p>
+      <p>Average Soil Health: {{ averageSoilHealth }}</p>
+      <button @click="restart">Restart Game</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue'
+import { useGameStateStore } from '../stores/game'
+import { useVillagerStore } from '../stores/villagers'
+import { useBoardStore } from '../stores/board'
+
+const game = useGameStateStore()
+const villagers = useVillagerStore()
+const board = useBoardStore()
+
+const visible = ref(false)
+
+watch(
+  () => game.gameOver,
+  val => {
+    if (val) {
+      visible.value = true
+    }
+  }
+)
+
+const finalScore = computed(() => game.score)
+const villagersServed = computed(() => Math.max(0, Math.floor(villagers.score / 10)))
+
+const averageSoilHealth = computed(() => {
+  const tiles = board.tiles
+  if (!tiles.length) return 0
+  const total = tiles.reduce((sum, t) => sum + t.soil.health.current, 0)
+  return Math.round(total / tiles.length)
+})
+
+function restart() {
+  game.resetGame()
+  visible.value = false
+}
+</script>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.panel {
+  background: white;
+  padding: 1rem 1.5rem;
+  max-width: 320px;
+  width: 100%;
+  text-align: center;
+}
+</style>

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -79,6 +79,28 @@ export const useGameStateStore = defineStore('game', () => {
     win.value = didWin
   }
 
+  function resetGame() {
+    day.value = 1
+    turn.value = 1
+    season.value = seasons[0]
+    weather.value = 'Normal'
+    activeEvents.value = []
+    score.value = 0
+    gameOver.value = false
+    win.value = false
+
+    const board = useBoardStore()
+    board.resetBoard()
+
+    const modules = useModulesStore()
+    modules.resetDailyUses()
+
+    const villagers = useVillagerStore()
+    if (villagers.reset) villagers.reset()
+
+    startDay()
+  }
+
   return {
     day,
     turn,
@@ -95,6 +117,7 @@ export const useGameStateStore = defineStore('game', () => {
     setEvents,
     triggerEvent,
     addScore,
-    endGame
+    endGame,
+    resetGame
   }
 })

--- a/src/stores/villagers.js
+++ b/src/stores/villagers.js
@@ -69,11 +69,18 @@ export const useVillagerStore = defineStore('villagers', () => {
     }
   }
 
+  function reset() {
+    activeVillagers.value = []
+    score.value = 0
+    villagerId = 0
+  }
+
   return {
     activeVillagers,
     score,
     generateNewVillagers,
     fulfillVillager,
-    decrementTimers
+    decrementTimers,
+    reset
   }
 })


### PR DESCRIPTION
## Summary
- add a `GameEndPanel` overlay component that shows when the game ends
- expose `resetGame` action in game state store
- add `reset` helper in villager store
- include overlay in the main app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866efccca0c8327bed63143108625fd